### PR TITLE
Deal with biggish Maildir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CXXFLAGS:=-std=gnu++17 -Wall -O2 -MMD -MP -ggdb -Iext/simplesocket -Iext/catch -pthread
+CXXFLAGS:=-std=gnu++14 -Wall -O2 -MMD -MP -ggdb -Iext/simplesocket -Iext/catch -pthread
 
 PROGRAMS = getsender
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ check: testrunner tdns tdig
 -include *.d
 
 getsender: getsender.o
-	g++ -std=gnu++14 $^ -o $@ -pthread
+	g++ -std=gnu++14 $^ -o $@ -pthread -lboost_system -lboost_filesystem
 
 
 testrunner: tests.o record-types.o dns-storage.o dnsmessages.o 

--- a/getsender.cc
+++ b/getsender.cc
@@ -16,7 +16,8 @@ static void chomp(char* p)
 string flattenDomain(const std::string& input, const vector<string>& repl)
 {
   for(const auto& r: repl) {
-    if(auto pos = input.find(r); pos != string::npos) {
+    auto pos = input.find(r);
+    if(pos != string::npos) {
       return "*."+r;
     }
   }
@@ -96,7 +97,8 @@ void processLine(std::string& l, MailTreeNode*& start)
 
 
   if(boost::starts_with(l, "Received: ")) {
-    if(auto pos = l.find(';'); pos != string::npos)
+    auto pos = l.find(';');
+    if(pos != string::npos)
       l.resize(pos);
     // Received: from server.ds9a.nl ([127.0.0.1]) by localhost (server.ds9a.nl [127.0.0.1]) (amavisd-new, port 10024) with ESMTP id CedExUADWeuK for <ahu@ds9a.nl>
 


### PR DESCRIPTION
I had a little play, and found the number of files in my ~/Maildir/cur/* leaves bash complaining the argument list is too long. So allow directories to be specified on the command line.

(I also had to retreat sufficiently from the C++ bleeding edge to allow compilation on Stretch).

So, just in case this is ever useful to anyone, an PR....